### PR TITLE
fix access token page in docs for go 

### DIFF
--- a/docs/guides/access-tokens.mdx
+++ b/docs/guides/access-tokens.mdx
@@ -48,9 +48,8 @@ import (
 )
 
 func getJoinToken(apiKey, apiSecret, room, identity string) (string, error) {
-
-  canPublish := true
-  canSubscribe := true
+    canPublish := true
+    canSubscribe := true
 
 	at := auth.NewAccessToken(apiKey, apiSecret)
 	grant := &auth.VideoGrant{

--- a/docs/guides/access-tokens.mdx
+++ b/docs/guides/access-tokens.mdx
@@ -48,12 +48,16 @@ import (
 )
 
 func getJoinToken(apiKey, apiSecret, room, identity string) (string, error) {
+
+  canPublish := true
+  canSubscribe := true
+
 	at := auth.NewAccessToken(apiKey, apiSecret)
 	grant := &auth.VideoGrant{
 		RoomJoin:     true,
 		Room:         room,
-		CanPublish:   true,
-		CanSubscribe: true,
+		CanPublish:   &canPublish,
+		CanSubscribe: &canSubscribe,
 	}
 	at.AddGrant(grant).
 		SetIdentity(identity).


### PR DESCRIPTION
CanPublish, CanSubscribe, CanPublishData field get only pointer type ( protocol/grants.go )
so livekit-docs go example is not working 
i changed it to working with pointer 

```
CanPublish     *bool `json:"canPublish,omitempty"`
CanSubscribe   *bool `json:"canSubscribe,omitempty"`
CanPublishData *bool `json:"canPublishData,omitempty"`
```