### PR TITLE
Fix typo in example

### DIFF
--- a/docs/guides/6-webhooks.mdx
+++ b/docs/guides/6-webhooks.mdx
@@ -9,7 +9,7 @@ LiveKit can be configured to notify your server when room events take place. Thi
 Webhooks can be enabled by setting the `webhook` section in config.
 
 ```yaml
-webook:
+webhook:
   api_key: 'api-key-to-sign-with'
   urls:
     - 'https://yourhost'


### PR DESCRIPTION
Fix typo for webhooks example:

`webook` -> `webhook`