### PR TITLE
fix docker name

### DIFF
--- a/docs/guides/1-getting-started.mdx
+++ b/docs/guides/1-getting-started.mdx
@@ -37,7 +37,7 @@ docker run --rm -p 7880:7880 \
     -p 7881:7881 \
     -p 7882:7882/udp \
     -v $PWD/livekit.yaml:/livekit.yaml \
-    livekit-server \
+    livekit/livekit-server \
     --config /livekit.yaml \
     --node-ip <machine-ip>
 ```


### PR DESCRIPTION
Looks like the commit from yesterday omitted the `livekit/` prefix